### PR TITLE
Add Next Section URL in IDE Plugins Page to Exceptions & Errors Page

### DIFF
--- a/app/Http/Controllers/IDEPluginsController.php
+++ b/app/Http/Controllers/IDEPluginsController.php
@@ -21,10 +21,15 @@ class IDEPluginsController extends Controller
      */
     public function __invoke(JetBrainsMarketplace $jetbrains, VisualStudioMarketplace $visualStudio, Documentation $docs)
     {
+        $document = $docs->get(config('site.defaultVersion'), 'ide-plugins');
+
+        $body = $document['html'];
+
         return view('ide', [
             'index' => $docs->getIndex(config('site.defaultVersion')),
             'jetbrains' => $jetbrains->downloadNumber(),
             'visualStudio' => $visualStudio->downloadNumber(),
+            'body' => $body,
         ]);
     }
 }

--- a/resources/views/ide.blade.php
+++ b/resources/views/ide.blade.php
@@ -37,6 +37,8 @@
                             github="https://github.com/m1guelpf/better-pest">
                         </x-ide-plugin>
                     </div>
+
+                    {!! $body !!}
                 </div>
             </div>
         </section>


### PR DESCRIPTION
I noticed the IDE Plugins Page is different from other pages in the documentation because it lacks the Next Section Button.

I also changed the Next Section URL in the Custom Helpers page to the IDE Plugins Page to improve the reading experience.

This is my first pull request. If there are any mistakes, please forgive me.