### PR TITLE
fix: allow disabling heading permalinks

### DIFF
--- a/app/Support/Documentation.php
+++ b/app/Support/Documentation.php
@@ -27,7 +27,9 @@ class Documentation
             $path = $this->path($version, 'documentation.md');
 
             if ($this->exists($version, 'documentation')) {
-                return (resolve(MarkdownParser::class))->convertToHtml($this->filesystem->get($path));
+                return (resolve(MarkdownParser::class))->convertToHtml($this->filesystem->get($path), [
+                    'enable_heading_permalinks' => false,
+                ]);
             }
 
             return null;

--- a/app/Support/MarkdownParser.php
+++ b/app/Support/MarkdownParser.php
@@ -26,17 +26,19 @@ class MarkdownParser
      * Converts CommonMark to HTML.
      *
      * @param string $markdown
+     * @param array{enable_heading_permalinks?: bool} $config
      * @return string
      */
-    public function convertToHtml(string $markdown)
+    public function convertToHtml(string $markdown, array $config = [])
     {
         $environment = Environment::createCommonMarkEnvironment();
 
-        $this->addDefaultExtensions($environment);
+        $this->addDefaultExtensions($environment, $config);
         $this->markdownStyler->stylise($environment);
 
         $converter = new CommonMarkConverter([
             'heading_permalink' => [
+                'html_class' => 'heading-permalink mr-2',
                 'inner_contents' => '#',
             ]
         ], $environment);
@@ -44,9 +46,12 @@ class MarkdownParser
         return $converter->convertToHtml($markdown);
     }
 
-    private function addDefaultExtensions(ConfigurableEnvironmentInterface $environment)
+    private function addDefaultExtensions(ConfigurableEnvironmentInterface $environment, array $config = [])
     {
-        $environment->addExtension(new HeadingPermalinkExtension());
+        if ($config['enable_heading_permalinks'] ?? true) {
+            $environment->addExtension(new HeadingPermalinkExtension());
+        }
+
         $environment->addExtension(new AutolinkExtension());
         $environment->addExtension(new DisallowedRawHtmlExtension());
         $environment->addExtension(new StrikethroughExtension());


### PR DESCRIPTION
This fixes the sidebar for documentation (following https://github.com/pestphp/pestphp.com/pull/32), this issue occurs because it also uses markdown to parse the sidebar.

**Before:**
![image](https://user-images.githubusercontent.com/1899334/154314343-5b52f600-3c35-482e-a869-7adc44c1c3cc.png)

**After:**
![image](https://user-images.githubusercontent.com/1899334/154314406-02a4010f-f680-479b-a419-bdaa99fc56f9.png)

----

I'm not entirely satisfied by the array configuration, so feel free to tweak it. 👍🏻