### PR TITLE
fix: Home should not have the class `dark`.

### DIFF
--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -29,25 +29,27 @@
 
     @stack('styles')
 
-    <script>
-        function updateTheme() {
-            if (!('mode' in localStorage)) {
-                localStorage.mode = 'light';
+    @if (! request()->is('/'))
+        <script>
+            function updateTheme() {
+                if (!('mode' in localStorage)) {
+                    localStorage.mode = 'light';
+                }
+
+                switch (localStorage.mode) {
+                    case 'dark':
+                        document.documentElement.classList.add('dark');
+                        break;
+
+                    case 'light':
+                        document.documentElement.classList.remove('dark');
+                        break;
+                }
             }
 
-            switch (localStorage.mode) {
-                case 'dark':
-                    document.documentElement.classList.add('dark');
-                    break;
-
-                case 'light':
-                    document.documentElement.classList.remove('dark');
-                    break;
-            }
-        }
-
-        updateTheme();
-    </script>
+            updateTheme();
+        </script>
+    @endif
 </head>
 <body {{ $attributes->except(['title', 'description']) }}>
 


### PR DESCRIPTION
## Issue
<img width="1335" alt="image" src="https://user-images.githubusercontent.com/823088/158038226-8dfda898-5bde-4c9e-bd8a-33cd63ab2711.png">

This happens on the homepage, so the solution is to not have the dark class.