### PR TITLE
Add IDE Plugin Entry for Neovim

### DIFF
--- a/app/View/Components/NeovimIdePlugin.php
+++ b/app/View/Components/NeovimIdePlugin.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\View\Components;
+
+class NeovimIdePlugin extends IdePlugin
+{
+    public ?int $installs = null;
+}

--- a/resources/views/components/ide-plugin.blade.php
+++ b/resources/views/components/ide-plugin.blade.php
@@ -1,7 +1,9 @@
 <div class="rounded-md shadow-dome border-gray-300 transition duration-200 ease-in-out px-16 py-12">
     <div class="flex flex-col lg:flex-row space-y-8 lg:space-y-0">
         <div class="flex lg:items-center justify-center bg-white rounded-full lg:shadow-dome py-6 px-6">
-            <img class="h-20 lg:h-16" src="{{ $logo }}" alt="{{ $title }} logo"/>
+            <div class="h-20 w-20 lg:h-16 lg:w-16 flex justify-center items-center">
+                <img class="w-full h-full object-center object-contain" src="{{ $logo }}" alt="{{ $title }} logo"/>
+            </div>
         </div>
         <div class="flex flex-col items-center justify-center lg:ml-16">
             <a class="text-2xl" target="_blank" rel="noopener" href="{{ $url }}">{{ $title }}</a>

--- a/resources/views/ide.blade.php
+++ b/resources/views/ide.blade.php
@@ -44,6 +44,13 @@
                             url="https://marketplace.visualstudio.com/items?itemName=dansysanalyst.pest-snippets"
                             github="https://github.com/dansysanalyst/pest-snippets">
                         </x-vs-code-ide-plugin>
+
+                        <x-neovim-ide-plugin
+                            title="Neovim (via Neotest)"
+                            logo="https://upload.wikimedia.org/wikipedia/commons/3/3a/Neovim-mark.svg"
+                            url="https://github.com/theutz/neotest-pest"
+                            github="https://github.com/theutz/neotest-pest">
+                        </x-ide-plugin>
                     </div>
 
                     {!! $body !!}


### PR DESCRIPTION
I recently wrote an [adapter](https://github.com/theutz/neotest-pest) for [neotest](https://github.com/nvim-neotest/neotest), which is an excellent test runner for Neovim. This PR adds a link to it in the IDE plugins section.

---
#### Note

I used the SVG from Wikipedia for the Neovim logo, as you had for the other IDE logos. However, the logo for Neovim does not have a square aspect ratio.

In order to keep a uniform, circular look to the logos, I changed the markup/styling at `resources/views/components/ide-plugin.blade.php`. As far as I can tell, it looks good. But it'd be worth double-checking on that, probably.