### PR TITLE
Create redirects from v1 docs

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -37,6 +37,7 @@ class Kernel extends HttpKernel
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \App\Http\Middleware\RedirectRequest::class
         ],
 
         'api' => [

--- a/app/Http/Middleware/RedirectRequest.php
+++ b/app/Http/Middleware/RedirectRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RedirectRequest
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $path = optional(config('redirects.redirects'))->get($request->path());
+        
+        if($path){
+            return redirect()->to($path, config('redirects.status') ?? 301);
+        }
+
+        return $next($request);
+    }
+}

--- a/config/redirects.php
+++ b/config/redirects.php
@@ -1,0 +1,41 @@
+<?php
+
+return [
+
+    /**
+     * Default status code to be used on the redirects
+     */
+    'status' => 301,
+    
+    /**
+     * Redirects
+     * ['old url' => 'new url']
+     */
+    'redirects' => [
+        'docs/underlying-test-case' => 'docs/configuring-tests',
+        'docs/assertions' => 'docs/writing-tests#content-assertion-api',
+        'docs/setup-and-teardown' => 'docs/hooks',
+        'docs/higher-order-tests' => 'docs/higher-order-testing',
+        'docs/helpers' => 'docs/configuring-tests',
+        'docs/ide-plugins' => 'docs/editor-setup',
+        'docs/exceptions-and-errors' => 'docs/expectations',
+        'docs/groups' => 'docs/grouping-tests',
+        'docs/test-dependency' => 'docs/test-dependencies',
+        'docs/coverage' => 'docs/test-coverage',
+        'docs/cli-options' => 'docs/cli-api-reference',
+        'docs/plugins/laravel' => 'docs/plugins',
+        'docs/plugins/livewire' => 'docs/plugins',
+        'docs/plugins/parallel' => 'docs/plugins',
+        'docs/plugins/mock' => 'docs/plugins',
+        'docs/plugins/money' => 'docs/plugins',
+        'docs/plugins/mutation-testing' => 'docs/plugins',
+        'docs/plugins/faker' => 'docs/plugins',
+        'docs/plugins/global-assertions' => 'docs/plugins',
+        'docs/plugins/snapshots' => 'docs/plugins',
+        'docs/plugins/time' => 'docs/plugins',
+        'docs/plugins/watch' => 'docs/plugins',
+        'docs/plugins/creating-plugins' => 'docs/plugins',
+        'docs/community' => 'docs/community-guide',
+        'docs/contribute' => 'docs/community-guide',
+    ]
+];

--- a/tests/Feature/RoutesTest.php
+++ b/tests/Feature/RoutesTest.php
@@ -7,3 +7,34 @@ it('has welcome page')
 it('has installation page')
     ->get('/docs/installation')
     ->assertStatus(200);
+
+it('can redirect old page', function (string $route) {
+    $this->get($route)
+        ->assertStatus(301);
+})->with([
+        'docs/underlying-test-case', 
+        'docs/assertions', 
+        'docs/setup-and-teardown', 
+        'docs/higher-order-tests', 
+        'docs/helpers', 
+        'docs/ide-plugins', 
+        'docs/exceptions-and-errors', 
+        'docs/groups', 
+        'docs/test-dependency', 
+        'docs/coverage', 
+        'docs/cli-options', 
+        'docs/plugins/laravel', 
+        'docs/plugins/livewire', 
+        'docs/plugins/parallel', 
+        'docs/plugins/mock', 
+        'docs/plugins/money', 
+        'docs/plugins/mutation-testing', 
+        'docs/plugins/faker', 
+        'docs/plugins/global-assertions', 
+        'docs/plugins/snapshots', 
+        'docs/plugins/time', 
+        'docs/plugins/watch', 
+        'docs/plugins/creating-plugins', 
+        'docs/community', 
+        'docs/contribute', 
+]);


### PR DESCRIPTION
This PR creates a middleware to deal with redirects from URLs of v1 documentation that doesn't exists anymore.