### PR TITLE
Delete `config/documentation.php`

### DIFF
--- a/config/documentation.php
+++ b/config/documentation.php
@@ -1,5 +1,0 @@
-<?php
-
-return [
-    'defaultVersion' => 'master',
-];


### PR DESCRIPTION
This pull request deletes the `config/documentation.php` config file, as it doesn't seem to be used anywhere. 

The `defaultVersion` is now defined in the `config/site.php` config instead.