### PR TITLE
Serve raw markdown files by appending .md extension to url

### DIFF
--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -25,6 +25,9 @@ class DocsController extends Controller
             return redirect()->route('docs', [self::DEFAULT_PAGE]);
         }
 
+        $isMarkdown = str($page)->endsWith('.md');
+        $page = str($page)->replace('.md', '')->toString();
+
         if (! $docs->exists(config('site.defaultVersion'), $page) || in_array($page, self::EXCLUDED)) {
             abort(404);
         }
@@ -36,6 +39,10 @@ class DocsController extends Controller
         $matter = $document['matter'];
         $markdown = $document['markdown'];
         $body = $document['html'];
+
+        if ($isMarkdown) {
+            return response($markdown, 200, ['Content-Type' => 'text/plain']);
+        }
 
         return view('docs', compact('body', 'matter', 'markdown', 'page', 'index'));
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,4 +23,3 @@ Route::group([
     Route::get('/docs/editor-setup', IDEPluginsController::class)->name('ide-plugins');
     Route::get('/docs/{page?}', DocsController::class)->name('docs')->where('page', '.*');
 });
-

--- a/tests/Browser/SmokeTest.php
+++ b/tests/Browser/SmokeTest.php
@@ -5,3 +5,7 @@ it('serve various pages without errors', function () {
 
     $response->assertNoSmoke();
 });
+
+it('serves pages in markdown format', function () {
+    visit('/docs/installation.md')->assertNoSmoke();
+});


### PR DESCRIPTION
👋 Hey, this adds the ability to append `.md` to a url to receive the raw markdown format for easier LLM usage, e.g.

`/docs/installation.md`

It would be great to have a general `/llms.txt` with an index of all the pages, as well as a copy as markdown on each page too but I don't have time for that just yet :) I can open another PR in the future if that is something you'd consider adding

I also couldn't get playwright to run locally (even though its working with pest 4 in other repos locally) so not sure if the test is passing, though I verified it works when serving the application itself and visiting the urls