### PR TITLE
add DEVSENSE.phptools-vscode extension

### DIFF
--- a/resources/views/ide.blade.php
+++ b/resources/views/ide.blade.php
@@ -39,6 +39,15 @@
                     </p>
 
                     <div class="space-y-6 mt-6">
+
+                        <x-vs-code-ide-plugin
+                            title="VSCode PHP Tools"
+                            extension="DEVSENSE.phptools-vscode"
+                            logo="https://raw.githubusercontent.com/DEVSENSE/phptools-docs/refs/heads/master/docs/vscode/imgs/phptools-icon.png"
+                            url="https://marketplace.visualstudio.com/items?itemName=DEVSENSE.phptools-vscode"
+                            github="hthttps://github.com/DEVSENSE/phptools-docs">
+                        </x-vs-code-ide-plugin>
+
                         <x-vs-code-ide-plugin
                             title="VSCode PHPUnit TestExplorer"
                             extension="recca0120.vscode-phpunit"


### PR DESCRIPTION
I would like to suggest adding [PHP Tools](https://marketplace.visualstudio.com/items?itemName=DEVSENSE.phptools-vscode) extension to the list of IDE plugins supporting Pest.

PHP Tools extension allows to do the following tasks form the VSCode's UI:

- Discover Pest tests and browse them in VSCode's Test Explorer window.
- Run Pest tests - either all, by suite, or by custom selection.
- Debug Pest test.
- Profile Pest test.
- Manage DataSets, and show failures with the test history for each of them separately.
- Allow to run a single data set.

Example screenshot:

<img width="1341" height="547" alt="image" src="https://github.com/user-attachments/assets/5f32c5b3-9670-4aa3-a430-101962bbe139" />
